### PR TITLE
Switch to Kqueue as Backing Event Loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Sample app for using NGINX Unit with vibe.d.
 
 To get started:  
 - Install NGINX Unit: https://unit.nginx.org/installation/
-- Run `dub build`.
+- Run `dub build` (`dub build --debug=Concurrency` to test with delays added to request handling).
 - Edit unit-config.json to replace "\<dub output directory\>" with your dub output directory.
 - Start Unit with `unitd --no-daemon` if it hasn't been started automatically.
 - Send the app config to Unit (the default control socket is in the docs for `--control` output by `unitd --help`):  

--- a/dub.json
+++ b/dub.json
@@ -4,23 +4,41 @@
 	],
 	"copyright": "Copyright © 2024, Kyle Ingraham",
 	"dependencies": {
-		"vibe-d": "~>0.10.1",
+		"eventcore": "~>0.9.34",
 		"lock-free": {
 			"repository": "git+https://github.com/MartinNowak/lock-free.git",
 			"version": "4d31e3866f2e6494a743df6c06dbe47f88fd0c53",
 		},
+		"vibe-d": "~>0.10.1",
 	},
 	"description": "A minimal NGINX Unit/vibe.d demo.",
 	"license": "MIT",
 	"name": "unit-vibed-hello-world",
-	"lflags-linux": [
-		"-lunit",
-	],
-	"lflags-osx": [
-		"-L/opt/homebrew/lib",
-		"-lunit",
-	],
-	"buildEnvironments-osx": {
-		"C_INCLUDE_PATH": "/opt/homebrew/include",
+	"configurations": {
+		"apple": {
+			"platforms": [
+				"osx",
+			],
+			"subConfigurations": {
+				"eventcore": "kqueue",
+			},
+			"buildEnvironments": {
+				"C_INCLUDE_PATH": "/opt/homebrew/include",
+			},
+			"lflags": [
+				"-L/opt/homebrew/lib",
+				"-lunit",
+			],
+			"targetType": "executable",
+		},
+		"linux": {
+			"platforms": [
+				"linux",
+			],
+			"lflags": [
+				"-lunit",
+			],
+			"targetType": "executable",
+		},
 	},
 }

--- a/dub.json
+++ b/dub.json
@@ -4,7 +4,11 @@
 	],
 	"copyright": "Copyright © 2024, Kyle Ingraham",
 	"dependencies": {
-		"vibe-d": "~>0.10.1"
+		"vibe-d": "~>0.10.1",
+		"lock-free": {
+			"repository": "git+https://github.com/MartinNowak/lock-free.git",
+			"version": "4d31e3866f2e6494a743df6c06dbe47f88fd0c53",
+		},
 	},
 	"description": "A minimal NGINX Unit/vibe.d demo.",
 	"license": "MIT",

--- a/dub.json
+++ b/dub.json
@@ -1,44 +1,44 @@
 {
-	"authors": [
-		"Kyle Ingraham"
-	],
-	"copyright": "Copyright © 2024, Kyle Ingraham",
-	"dependencies": {
-		"eventcore": "~>0.9.34",
-		"lock-free": {
-			"repository": "git+https://github.com/MartinNowak/lock-free.git",
-			"version": "4d31e3866f2e6494a743df6c06dbe47f88fd0c53",
-		},
-		"vibe-d": "~>0.10.1",
-	},
-	"description": "A minimal NGINX Unit/vibe.d demo.",
-	"license": "MIT",
-	"name": "unit-vibed-hello-world",
-	"configurations": {
-		"apple": {
-			"platforms": [
-				"osx",
-			],
-			"subConfigurations": {
-				"eventcore": "kqueue",
-			},
-			"buildEnvironments": {
-				"C_INCLUDE_PATH": "/opt/homebrew/include",
-			},
-			"lflags": [
-				"-L/opt/homebrew/lib",
-				"-lunit",
-			],
-			"targetType": "executable",
-		},
-		"linux": {
-			"platforms": [
-				"linux",
-			],
-			"lflags": [
-				"-lunit",
-			],
-			"targetType": "executable",
-		},
-	},
+    "authors": [
+        "Kyle Ingraham"
+    ],
+    "copyright": "Copyright © 2024, Kyle Ingraham",
+    "dependencies": {
+        "eventcore": "~>0.9.34",
+        "lock-free": {
+            "repository": "git+https://github.com/MartinNowak/lock-free.git",
+            "version": "4d31e3866f2e6494a743df6c06dbe47f88fd0c53",
+        },
+        "vibe-d": "~>0.10.1",
+    },
+    "description": "A minimal NGINX Unit/vibe.d demo.",
+    "license": "MIT",
+    "name": "unit-vibed-hello-world",
+    "configurations": {
+        "apple": {
+            "platforms": [
+                "osx",
+            ],
+            "subConfigurations": {
+                "eventcore": "kqueue",
+            },
+            "buildEnvironments": {
+                "C_INCLUDE_PATH": "/opt/homebrew/include",
+            },
+            "lflags": [
+                "-L/opt/homebrew/lib",
+                "-lunit",
+            ],
+            "targetType": "executable",
+        },
+        "linux": {
+            "platforms": [
+                "linux",
+            ],
+            "lflags": [
+                "-lunit",
+            ],
+            "targetType": "executable",
+        },
+    },
 }

--- a/source/app.d
+++ b/source/app.d
@@ -122,7 +122,7 @@ void dispatch(RequestInfoMessage message)
             ushort statusCode = 200;
             auto response = "Hello, World!\n";
             auto contentType = ["Content-Type", "text/plain"];
-            sleep(10.msecs); // Test that vibe.d's concurrency system works.
+            //sleep(10.msecs); // Test that vibe.d's concurrency system works.
             auto rc = nxt_unit_response_init(
                 requestInfo,
                 statusCode,

--- a/source/app.d
+++ b/source/app.d
@@ -1,6 +1,5 @@
 import core.atomic : atomicOp;
 import core.sync.mutex : Mutex;
-import core.time : msecs;
 import core.thread : Thread;
 import lock_free.rwqueue : RWQueue;
 import std.concurrency : ownerTid, receive, receiveOnly, spawn, thisTid;
@@ -114,6 +113,7 @@ struct RequestInfoMessage
 
 void dispatch(RequestInfoMessage message)
 {
+    import core.time : msecs;
     import vibe.core.core : sleep;
 
     runTask((nxt_unit_request_info_t* requestInfo) {
@@ -122,7 +122,7 @@ void dispatch(RequestInfoMessage message)
             ushort statusCode = 200;
             auto response = "Hello, World!\n";
             auto contentType = ["Content-Type", "text/plain"];
-            //sleep(10.msecs); // Test that vibe.d's concurrency system works.
+            sleep(10.msecs); // Test that vibe.d's concurrency system works.
             auto rc = nxt_unit_response_init(
                 requestInfo,
                 statusCode,


### PR DESCRIPTION
Switch to Kqueue as the backing event loop.
CFRunLoop was found to be inefficient for
serving web requests:
 - https://github.com/vibe-d/vibe.d/issues/2807