### PR TITLE
Return to Message Passing

### DIFF
--- a/dub.json
+++ b/dub.json
@@ -5,10 +5,6 @@
     "copyright": "Copyright © 2024, Kyle Ingraham",
     "dependencies": {
         "eventcore": "~>0.9.34",
-        "lock-free": {
-            "repository": "git+https://github.com/MartinNowak/lock-free.git",
-            "version": "4d31e3866f2e6494a743df6c06dbe47f88fd0c53",
-        },
         "vibe-d": "~>0.10.1",
     },
     "description": "A minimal NGINX Unit/vibe.d demo.",


### PR DESCRIPTION
    Return to message passing instead of queues now
    that we have determined that performance issues
    were due to using CFRunLoop over Kqueue. This
    greatly simplifies the implementation.